### PR TITLE
修复64位机器上内存操作错误（EXC_BAD_ACCESS )

### DIFF
--- a/tutorial/en/2-Virtual-Machine.md
+++ b/tutorial/en/2-Virtual-Machine.md
@@ -156,7 +156,7 @@ have any code generation yet, thus skip for now.
     memset(stack, 0, poolsize);
     ...
 
-    bp = sp = (int *)((int)stack + poolsize);
+    bp = sp = stack + poolsize/sizeof(int);
     ax = 0;
 
     ...


### PR DESCRIPTION
`bp = sp = (int *)((int)stack + poolsize );`中 stack强转为int 后在64位机器上有可能出错