### PR TITLE
bugfix for pointer cast in 64 bit machine

### DIFF
--- a/xc-tutor.c
+++ b/xc-tutor.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
     memset(text, 0, poolsize);
     memset(data, 0, poolsize);
     memset(stack, 0, poolsize);
-    bp = sp = (int *)((int)stack + poolsize);
+    bp = sp = (int *)((long)stack + poolsize);
     ax = 0;
 
 


### PR DESCRIPTION
我在 Mac 和 linux 的 64 位机器上跑都是 coredump，我打印了 malloc 后的地址发现值大于 32 位 int 所表示的范围，所以我决定这里如果用 int 转化可能已经截断了导致后面内存出错了