### PR TITLE
fix(miss_headers): Add necessary headers for file control

### DIFF
--- a/xc-tutor.c
+++ b/xc-tutor.c
@@ -6,6 +6,8 @@
 #include <memory.h>
 #include <string.h>
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
 #define int intptr_t
 
 int token;                    // current token

--- a/xc.c
+++ b/xc.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
 #define int long long // to work with 64bit address
 
 int debug;    // print the executed instructions


### PR DESCRIPTION
As the gcc suggestion, previous version miss required headers and use implict-function-declaration to pass
`xc-tutor.c:1238:37: error: implicit declaration of function ‘open’; did you mean ‘popen’? [-Wimplicit-function-declaration]
 1238 |         else if (op == OPEN) { ax = open((char *)sp[1], sp[0]); }
      |                                     ^~~~
      |                                     popen
xc-tutor.c:1239:37: error: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
 1239 |         else if (op == CLOS) { ax = close(*sp);}
      |                                     ^~~~~
      |                                     pclose
xc-tutor.c:1240:37: error: implicit declaration of function ‘read’; did you mean ‘fread’? [-Wimplicit-function-declaration]
 1240 |         else if (op == READ) { ax = read(sp[2], (char *)sp[1], *sp); }`
According to the linux man page, open is in <fcntl.h>, and read, close are in <unistd.h>
So I made this pr